### PR TITLE
Readmes for examples

### DIFF
--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,0 +1,18 @@
+# Counter Example
+
+## Install
+
+```
+npm install
+```
+
+## Run
+
+```
+$ npm run start
+
+> counter@0.1.0 start /Users/rgbkrk/code/philpl/fluorine/examples/counter
+> node server.js
+
+☕️  Server is listening on localhost:8080.
+```

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -11,7 +11,7 @@ npm install
 ```
 $ npm run start
 
-> todo@0.1.0 start /Users/kyle6475/code/src/github.com/philpl/fluorine/examples/todo
+> todo@0.1.0 start /Users/rgbkrk/code/philpl/fluorine/examples/todo
 > node server.js
 
 ☕️  Server is listening on localhost:8000.

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -1,0 +1,18 @@
+# TODO
+
+## Install
+
+```
+npm install
+```
+
+## Run
+
+```
+$ npm run start
+
+> todo@0.1.0 start /Users/kyle6475/code/src/github.com/philpl/fluorine/examples/todo
+> node server.js
+
+☕️  Server is listening on localhost:8000.
+```

--- a/examples/todo/src/components/TodoTextInput.jsx
+++ b/examples/todo/src/components/TodoTextInput.jsx
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react'
-import { withStore, withActions } from 'fluorine-lib'
 
 export default class TodoTextInput extends Component {
   static propTypes = {


### PR DESCRIPTION
Adding on READMEs for the examples (for install and run), removed an unused import in the Todo example.