### PR TITLE
Turn the dispatcher into an actual Rx Subject

### DIFF
--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -16,17 +16,8 @@ import {
 } from './util/logger'
 
 import assert from './util/assert'
-
-function isPromise(obj) {
-  return typeof obj === 'object' && typeof obj.then === 'function'
-}
-
-function isObservable(obj) {
-  return (
-    typeof obj === 'object' &&
-    typeof obj.subscribe === 'function'
-  )
-}
+import isPromise from './util/isPromise'
+import isObservable from './util/isObservable'
 
 const KICKSTART_ACTION = { type: '_INIT_' }
 

--- a/src/createDispatcher.js
+++ b/src/createDispatcher.js
@@ -185,7 +185,14 @@ export default function createDispatcher(opts = {}) {
     throw new Error('Expected either an action creator or an array/object containing some as arguments.')
   }
 
-  return Object.assign(dispatcher.mergeAll(), {
+  return Object.assign(Object.create(dispatcher), {
+    next(obj) {
+      if (isObservable(obj)) {
+        schedule(obj)
+      } else {
+        dispatch(obj)
+      }
+    },
     dispatch,
     schedule,
     reduce,

--- a/src/util/isObservable.js
+++ b/src/util/isObservable.js
@@ -1,0 +1,7 @@
+export default function isObservable(obj) {
+  return (
+    typeof obj === 'object' &&
+    typeof obj.subscribe === 'function'
+  )
+}
+

--- a/src/util/isPromise.js
+++ b/src/util/isPromise.js
@@ -1,0 +1,4 @@
+export default function isPromise(obj) {
+  return typeof obj === 'object' && typeof obj.then === 'function'
+}
+

--- a/test/dispatcher.js
+++ b/test/dispatcher.js
@@ -1,14 +1,8 @@
 import createDispatcher from '../src/createDispatcher'
+import isObservable from '../src/util/isObservable'
 import { Observable } from '@reactivex/rxjs'
 
 const action = { type: 'Test' }
-
-function isObservable(obj) {
-  return (
-    typeof obj === 'object' &&
-    typeof obj.subscribe === 'function'
-  )
-}
 
 describe('Dispatcher', () => {
   it('is an Observable emitting agendas', () => {

--- a/test/dispatcher.js
+++ b/test/dispatcher.js
@@ -1,0 +1,49 @@
+import createDispatcher from '../src/createDispatcher'
+import { Observable } from '@reactivex/rxjs'
+
+const action = { type: 'Test' }
+
+function isObservable(obj) {
+  return (
+    typeof obj === 'object' &&
+    typeof obj.subscribe === 'function'
+  )
+}
+
+describe('Dispatcher', () => {
+  it('is an Observable emitting agendas', () => {
+    const dispatcher = createDispatcher()
+    const first = dispatcher
+      .first()
+      .publishReplay()
+
+    expect(first.every(x => isObservable(x))).toBeTruthy()
+
+    first
+      .mergeAll()
+      .subscribe(x => expect(x).toEqual(action))
+
+    dispatcher.dispatch(action)
+  })
+
+  it('is an Observer taking actions, thunks, promises and agendas', () => {
+    const dispatcher = createDispatcher()
+    const first = dispatcher
+      .first()
+      .publishReplay()
+
+    expect(first.every(x => isObservable(x))).toBeTruthy()
+
+    first
+      .mergeAll()
+      .subscribe(x => expect(x).toEqual(action))
+
+    Observable
+      .of(
+        action, // action
+        dispatch => dispatch(action), // thunk
+        Promise.resolve(action), // promise
+        Observable.of(action) // agenda
+      ).subscribe(dispatcher.next)
+  })
+})

--- a/test/dispatcher/dispatch.js
+++ b/test/dispatcher/dispatch.js
@@ -1,8 +1,5 @@
 import createDispatcher from '../../src/createDispatcher'
-
-function isPromise(obj) {
-  return Promise.prototype.isPrototypeOf(obj)
-}
+import isPromise from '../../src/util/isPromise'
 
 const init = { type: '_INIT_' }
 const action = { type: 'Test' }

--- a/test/dispatcher/schedule.js
+++ b/test/dispatcher/schedule.js
@@ -1,9 +1,7 @@
 import createDispatcher from '../../src/createDispatcher'
+import isPromise from '../../src/util/isPromise'
 import { Observable } from 'rxjs'
 
-function isPromise(obj) {
-  return Promise.prototype.isPrototypeOf(obj)
-}
 
 function AdderStore(state = 0, action) {
   switch (action.type) {

--- a/test/dispatcher/wrapActions.js
+++ b/test/dispatcher/wrapActions.js
@@ -10,6 +10,7 @@ describe('Dispatcher.wrapActions', () => {
     const dispatcher = createDispatcher()
 
     dispatcher
+      .mergeAll()
       .bufferCount(1)
       .subscribe(x => {
         expect(x).toEqual([ action ])
@@ -22,6 +23,7 @@ describe('Dispatcher.wrapActions', () => {
     const dispatcher = createDispatcher()
 
     dispatcher
+      .mergeAll()
       .bufferCount(1)
       .subscribe(x => {
         expect(x).toEqual([ action ])
@@ -38,6 +40,7 @@ describe('Dispatcher.wrapActions', () => {
     const dispatcher = createDispatcher()
 
     dispatcher
+      .mergeAll()
       .bufferCount(1)
       .subscribe(x => {
         expect(x).toEqual([ action ])


### PR DESCRIPTION
The goal of this PR is to make Fluorine's API easier and compatible with more Rx features.

### Changes

- Make dispatcher inherit its subject directly and override `next` to convert inputs into Observables.