### PR TITLE
Add a `connect` decorator and a Provider

### DIFF
--- a/src/Provider.js
+++ b/src/Provider.js
@@ -12,8 +12,9 @@ export default class Provider extends Component {
   };
 
   getChildContext() {
-    assert(isObservable(this.props.observable), 'Expect prop observable to be an observable.')
-    return { observable: this.props.observable }
+    const { observable } = this.props
+    assert(isObservable(observable), 'Expected prop observable to be an Observable.')
+    return { observable }
   }
 
   render() {

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -1,20 +1,10 @@
 import React, { Component } from 'react'
-
 import assert from './util/assert'
-import createDispatcher from './createDispatcher'
-
-function isDispatcher(obj) {
-  return (
-    typeof obj === 'object' &&
-    typeof obj.subscribe === 'function' &&
-    typeof obj.reduce === 'function' &&
-    typeof obj.schedule === 'function'
-  )
-}
+import isObservable from './util/isObservable'
 
 export default class Provider extends Component {
   static propTypes = {
-    dispatcher: React.PropTypes.object
+    observable: React.PropTypes.object.isRequired
   };
 
   static childContextTypes = {
@@ -22,16 +12,8 @@ export default class Provider extends Component {
   };
 
   getChildContext() {
-    if (this.props.dispatcher) {
-      assert(isDispatcher(this.props.dispatcher), 'Expected a Dispatcher to be passed in the dispatcher prop.')
-      return { dispatcher: this.props.dispatcher }
-    }
-
-    if (!this.dispatcher) {
-      this.dispatcher = createDispatcher()
-    }
-
-    return { dispatcher: this.dispatcher }
+    assert(isObservable(this.props.observable), 'Expect prop observable to be an observable.')
+    return { observable: this.props.observable }
   }
 
   render() {

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react'
+
+import assert from './util/assert'
+import createDispatcher from './createDispatcher'
+
+function isDispatcher(obj) {
+  return (
+    typeof obj === 'object' &&
+    typeof obj.subscribe === 'function' &&
+    typeof obj.reduce === 'function' &&
+    typeof obj.schedule === 'function'
+  )
+}
+
+export default class Provider extends Component {
+  static propTypes = {
+    dispatcher: React.PropTypes.object
+  };
+
+  static childContextTypes = {
+    dispatcher: React.PropTypes.object
+  };
+
+  getChildContext() {
+    if (this.props.dispatcher) {
+      assert(isDispatcher(this.props.dispatcher), 'Expected a Dispatcher to be passed in the dispatcher prop.')
+      return { dispatcher: this.props.dispatcher }
+    }
+
+    if (!this.dispatcher) {
+      this.dispatcher = createDispatcher()
+    }
+
+    return { dispatcher: this.dispatcher }
+  }
+
+  render() {
+    return this.props.children
+  }
+}

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -8,7 +8,7 @@ export default class Provider extends Component {
   };
 
   static childContextTypes = {
-    dispatcher: React.PropTypes.object
+    observable: React.PropTypes.object
   };
 
   getChildContext() {

--- a/src/connect.js
+++ b/src/connect.js
@@ -77,10 +77,11 @@ export default function connect(selector, prop = 'data') {
       if (
         this.context &&
         this.context.observable &&
-        isDispatcher(this.context.obervable)
+        isDispatcher(this.context.observable)
       ) {
         props.schedule = this.context.observable.schedule
         props.dispatch = this.context.observable.dispatch
+        props.next = this.context.observable.next
       }
 
       return (

--- a/src/connect.js
+++ b/src/connect.js
@@ -6,18 +6,18 @@ import isDispatcher from './util/isDispatcher'
 export default function connect(selector, prop = 'data') {
   return Child => class Connector extends Component {
     static contextTypes = {
-      observable: React.PropTypes.object.isRequired
+      observable: React.PropTypes.object
     }
 
     constructor(props) {
       super(props)
 
-      const { observable } = this.context
-      assert(isObservable(observable), 'Expected context to contain an observable.')
-
+      this.observable = this.context ? this.context.observable : undefined
       this.store = typeof selector === 'function' ?
-        selector(observable, props) :
+        selector(this.observable, props) :
         selector
+
+      this.state = {}
     }
 
     subscribe = () => {
@@ -50,8 +50,7 @@ export default function connect(selector, prop = 'data') {
 
     componentWillReceiveProps(props) {
       if (typeof selector === 'function') {
-        const { observable } = this.context
-        const _store = selector(observable, props)
+        const _store = selector(this.observable, props)
 
         if (this.store !== _store) {
           this.store = _store
@@ -66,7 +65,6 @@ export default function connect(selector, prop = 'data') {
     }
 
     render() {
-      const { observable } = this.context
       const { data } = this.state
 
       if (data === undefined) {
@@ -77,10 +75,10 @@ export default function connect(selector, prop = 'data') {
         [prop]: data
       }
 
-      if (isDispatcher(obervable)) {
-        props.dispatcher = observable
-        props.schedule = observable.schedule
-        props.dispatch = observable.dispatch
+      if (isDispatcher(this.obervable)) {
+        props.dispatcher = this.observable
+        props.schedule = this.observable.schedule
+        props.dispatch = this.observable.dispatch
       }
 
       return (

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,0 +1,92 @@
+import React, { Component } from 'react'
+import assert from './util/assert'
+import isObservable from './util/isObservable'
+import isDispatcher from './util/isDispatcher'
+
+export default function connect(selector, prop = 'data') {
+  return Child => class Connector extends Component {
+    static contextTypes = {
+      observable: React.PropTypes.object.isRequired
+    }
+
+    constructor(props) {
+      super(props)
+
+      const { observable } = this.context
+      assert(isObservable(observable), 'Expected context to contain an observable.')
+
+      this.store = typeof selector === 'function' ?
+        selector(observable, props) :
+        selector
+    }
+
+    subscribe = () => {
+      this.sub = this.store.subscribe(next => {
+        this.setState({
+          data: next
+        })
+      }, err => {
+        throw err
+      })
+    }
+
+    componentWillMount() {
+      this.subscribe()
+    }
+
+    shouldComponentUpdate(props, state) {
+      if (state.data !== this.state.data) {
+        return true
+      }
+
+      for (const key in props) {
+        if (props.hasOwnProperty(key) && props[key] !== this.props[key]) {
+          return true
+        }
+      }
+
+      return false
+    }
+
+    componentWillReceiveProps(props) {
+      if (typeof selector === 'function') {
+        const { observable } = this.context
+        const _store = selector(observable, props)
+
+        if (this.store !== _store) {
+          this.store = _store
+          this.sub.unsubscribe()
+          this.subscribe()
+        }
+      }
+    }
+
+    componentWillUnmount() {
+      this.sub.unsubscribe()
+    }
+
+    render() {
+      const { observable } = this.context
+      const { data } = this.state
+
+      if (data === undefined) {
+        return null
+      }
+
+      const props = {
+        [prop]: data
+      }
+
+      if (isDispatcher(obervable)) {
+        props.dispatcher = observable
+        props.schedule = observable.schedule
+        props.dispatch = observable.dispatch
+      }
+
+      return (
+        <Child {...this.props} {...props}/>
+      )
+    }
+  }
+}
+

--- a/src/connect.js
+++ b/src/connect.js
@@ -9,12 +9,11 @@ export default function connect(selector, prop = 'data') {
       observable: React.PropTypes.object
     }
 
-    constructor(props) {
-      super(props)
+    constructor(props, context = {}) {
+      super(props, context)
 
-      this.observable = this.context ? this.context.observable : undefined
       this.store = typeof selector === 'function' ?
-        selector(this.observable, props) :
+        selector(this.context.observable, props) :
         selector
 
       this.state = {}
@@ -50,7 +49,7 @@ export default function connect(selector, prop = 'data') {
 
     componentWillReceiveProps(props) {
       if (typeof selector === 'function') {
-        const _store = selector(this.observable, props)
+        const _store = selector(this.context.observable, props)
 
         if (this.store !== _store) {
           this.store = _store
@@ -75,10 +74,13 @@ export default function connect(selector, prop = 'data') {
         [prop]: data
       }
 
-      if (isDispatcher(this.obervable)) {
-        props.dispatcher = this.observable
-        props.schedule = this.observable.schedule
-        props.dispatch = this.observable.dispatch
+      if (
+        this.context &&
+        this.context.observable &&
+        isDispatcher(this.context.obervable)
+      ) {
+        props.schedule = this.context.observable.schedule
+        props.dispatch = this.context.observable.dispatch
       }
 
       return (

--- a/src/util/isDispatcher.js
+++ b/src/util/isDispatcher.js
@@ -1,0 +1,8 @@
+export default function isDispatcher(obj) {
+  return (
+    typeof obj === 'object' &&
+    typeof obj.dispatch === 'function' &&
+    typeof obj.schedule === 'function' &&
+    typeof obj.reduce === 'function'
+  )
+}

--- a/src/withStore.js
+++ b/src/withStore.js
@@ -1,70 +1,11 @@
-import React, { Component } from 'react'
-import assert from './util/assert'
-import {
-  Observable
-} from '@reactivex/rxjs'
+import connect from './connect'
 
+// The withStore decorator is deprecated and will be deleted in favor
+// for the connect decorator soon
 export default function withStore(store, prop = 'data') {
-  return Child => class StoreContainer extends Component {
-    constructor(props) {
-      super(props)
-
-      if (typeof store === 'function') {
-        this.store = store(props)
-      } else {
-        this.store = store
-      }
-
-      assert(this.store instanceof Observable, 'Expected `store` to be an Observable.')
-
-      this.state = {
-        data: undefined
-      }
-    }
-
-    subscribe() {
-      if (this.sub) {
-        this.sub.unsubscribe()
-      }
-
-      this.sub = this.store.subscribe(next => {
-        this.setState({
-          data: next
-        })
-      }, err => {
-        throw err
-      })
-    }
-
-    componentWillMount() {
-      this.subscribe()
-    }
-
-    componentWillReceiveProps(newProps) {
-      if (typeof store === 'function') {
-        const newStore = store(newProps)
-
-        if (newStore !== this.store) {
-          this.store = newStore
-          this.subscribe()
-        }
-      }
-    }
-
-    componentWillUnmount() {
-      this.sub.unsubscribe()
-    }
-
-    render() {
-      if (this.state.data === undefined) {
-        return null
-      }
-
-      return (
-        <Child {...this.props} {...{
-          [prop]: this.state.data
-        }}/>
-      )
-    }
+  if (typeof store === 'function') {
+    return connect((_, props) => store(props), prop)
   }
+
+  return connect(store, prop)
 }

--- a/src/withStore.js
+++ b/src/withStore.js
@@ -9,3 +9,4 @@ export default function withStore(store, prop = 'data') {
 
   return connect(store, prop)
 }
+

--- a/test/Provider.js
+++ b/test/Provider.js
@@ -1,0 +1,26 @@
+import test from 'ava'
+
+import React, { Component } from 'react'
+import { Observable } from '@reactivex/rxjs'
+import { mount } from 'enzyme'
+
+import connect from '../lib/connect'
+import Provider from '../lib/Provider'
+
+function Child({data}) {
+  return <div>{data}</div>
+}
+
+test('passes the observable down to connect', t => {
+  const Tester = connect(observable => observable.map(x => `${x} world`))(Child)
+
+  const wrapper = mount(
+    <Provider observable={Observable.of('hello')}>
+      <Tester/>
+    </Provider>
+  )
+
+  const testerWrapper = wrapper.find(Tester).first()
+  t.is(testerWrapper.text(), 'hello world')
+})
+

--- a/test/Provider.js
+++ b/test/Provider.js
@@ -6,6 +6,7 @@ import { mount } from 'enzyme'
 
 import connect from '../lib/connect'
 import Provider from '../lib/Provider'
+import createDispatcher from '../lib/createDispatcher'
 
 function Child({data}) {
   return <div>{data}</div>
@@ -22,5 +23,28 @@ test('passes the observable down to connect', t => {
 
   const testerWrapper = wrapper.find(Tester).first()
   t.is(testerWrapper.text(), 'hello world')
+})
+
+test('connect passes dispatch, schedule and next', t => {
+  t.plan(6)
+  const dispatcher = createDispatcher()
+
+  const Tester = connect(() => Observable.of('static'))(props => {
+    t.is(typeof props.schedule, 'function')
+    t.is(typeof props.dispatch, 'function')
+    t.is(typeof props.next, 'function')
+
+    t.is(props.schedule, dispatcher.schedule)
+    t.is(props.dispatch, dispatcher.dispatch)
+    t.is(props.next, dispatcher.next)
+
+    return <div>{props.data}</div>
+  })
+
+  const wrapper = mount(
+    <Provider observable={dispatcher}>
+      <Tester/>
+    </Provider>
+  )
 })
 

--- a/test/connect.js
+++ b/test/connect.js
@@ -1,0 +1,77 @@
+import test from 'ava'
+
+import React, { Component } from 'react'
+import { Observable } from '@reactivex/rxjs'
+import { mount } from 'enzyme'
+
+import connect from '../lib/connect'
+import createDispatcher from '../lib/createDispatcher'
+
+function Child({data}) {
+  return <div>{data}</div>
+}
+
+// connect tested in combination with the Provider is in
+// the Provider test file
+
+test('passes the correct static observable value', t => {
+  const Tester = connect(Observable.of('test'))(Child)
+
+  const wrapper = mount(<Tester/>)
+
+  t.is(wrapper.text(), 'test')
+  t.is(wrapper.state('data'), 'test')
+})
+
+test('passes selector-applied observable value based on props', t => {
+  const Tester = connect((_, { test }) => Observable.of(test))(Child)
+
+  const wrapper = mount(<Tester test='hello world'/>)
+
+  t.is(wrapper.text(), 'hello world')
+  t.is(wrapper.state('data'), 'hello world')
+})
+
+test('subscribes to state and updates children', t => {
+  const something = { type: 'DO_SOMETHING' }
+
+  const reducer = (state = 'NOTHING', action) => {
+    switch (action.type) {
+      case 'DO_SOMETHING': return state + 'X'
+      default: return state
+    }
+  }
+
+  const dispatcher = createDispatcher()
+  const Tester = connect(() => dispatcher.reduce(reducer))(Child)
+
+  const wrapper = mount(<Tester/>)
+
+  dispatcher
+    .reduce(reducer)
+    .take(3)
+    .subscribe(x => {
+      t.is(wrapper.text(), x)
+      t.is(wrapper.state('data'), x)
+    }, err => {
+      t.fail()
+    }, () => {
+      t.end()
+    })
+
+  dispatcher.dispatch(something)
+  dispatcher.dispatch(something)
+})
+
+test('recomputes selector-applied observables on changing props', t => {
+  const data = { a: 'a', b: 'b' }
+
+  const Tester = connect((_, {id}) => Observable.of(data[id]))(Child)
+
+  const wrapper = mount(<Tester id='a'/>)
+
+  t.is(wrapper.text(), 'a')
+  wrapper.setProps({ id: 'b' })
+  t.is(wrapper.text(), 'b')
+})
+

--- a/test/dispatcher/wrapActions.js
+++ b/test/dispatcher/wrapActions.js
@@ -8,6 +8,7 @@ function createAction() {
 }
 
 test('wraps an action creator', t => {
+  t.plan(1)
   const dispatcher = createDispatcher()
 
   dispatcher
@@ -21,6 +22,7 @@ test('wraps an action creator', t => {
 })
 
 test('wraps action creators in objects', t => {
+  t.plan(1)
   const dispatcher = createDispatcher()
 
   dispatcher
@@ -38,6 +40,7 @@ test('wraps action creators in objects', t => {
 })
 
 test('wraps action creators in arrays', t => {
+  t.plan(1)
   const dispatcher = createDispatcher()
 
   dispatcher

--- a/test/withStore.js
+++ b/test/withStore.js
@@ -9,43 +9,10 @@ function Child({data}) {
   return <div>{data}</div>
 }
 
-test('passes the correct reductions', t => {
-  const something = {
-    type: 'DO_SOMETHING'
-  }
+// Basically an identical test to one in the connect
+// tests but with the withStore signature
 
-  const reducer = (state, action) => {
-    if (!state) {
-      state = 'NOTHING'
-    }
-
-    switch (action.type) {
-      case 'DO_SOMETHING': return 'SOMETHING'
-      default: return state
-    }
-  }
-
-  const dispatcher = createDispatcher()
-  const Tester = withStore(dispatcher.reduce(reducer))(Child)
-
-  const wrapper = mount(<Tester/>)
-
-  dispatcher
-    .reduce(reducer)
-    .take(2)
-    .subscribe(x => {
-      t.is(wrapper.text(), x)
-      t.is(wrapper.state('data'), x)
-    }, err => {
-      t.fail()
-    }, () => {
-      t.end()
-    })
-
-  dispatcher.dispatch(something)
-})
-
-test('recompute dynamically generated observables', t => {
+test('wraps around connect correctly', t => {
   const reducer = () => {
     return { a: 'a', b: 'b' }
   }
@@ -57,20 +24,7 @@ test('recompute dynamically generated observables', t => {
     .map(x => x[id]))
     (Child)
 
-  class Switcher extends Component {
-    constructor(props) {
-      super(props)
-      this.state = {
-        id: 'a'
-      };
-    }
-
-    render() {
-      return <Tester id={this.state.id}/>
-    }
-  }
-
-  const wrapper = mount(<Switcher/>)
+  const wrapper = mount(<Tester id='a'/>)
 
   dispatcher
     .reduce(reducer)
@@ -78,7 +32,7 @@ test('recompute dynamically generated observables', t => {
     .subscribe(() => {
       t.is(wrapper.text(), 'a')
 
-      tree.setState({ id: 'b' })
+      wrapper.setProps({ id: 'b' })
       t.is(wrapper.text(), 'b')
     }, err => {
       t.fail()


### PR DESCRIPTION
The Provider can pass down an observable (be it a store or a dispatcher) like so.

```js
<Provider observable={dispatcher}>
  <App/>
</Provider>
```

Then the connect decorator can be used to inject state. This decorator would replace `withStore`, which is deprecated. The connect decorator takes a "selector" function and a prop name.

The selector function is used to transform the observable, that is passed down through the context from a provider, optionally using props.

```js
@connect((dispatcher, props) => dispatcher.reduce(anyStore), 'anyState')
```

it can also take static observables:

```js
@connect(dispatcher.reduce(anyStore), 'anyState')
```

and is also perfect for passing down a "mono-store":

```js
<Provider observable={dispatcher.reduce(anyStore)}/>
@connect(anyStore.pluck('data'), 'data')
```