### PR TITLE
Correct example to use thunkedTodos instead of fetchTodos

### DIFF
--- a/docs/concepts/actions-and-thunks.md
+++ b/docs/concepts/actions-and-thunks.md
@@ -152,7 +152,7 @@ method will inject a dispatch method into a thunk's first
 argument automatically:
 
 ```js
-dispatcher.next(fetchTodos())
+dispatcher.next(thunkedTodos())
 ```
 
 The usage hasn't changed compared to promises.


### PR DESCRIPTION
The example is talking about thunk, but in the code snippet, it reused fetchTodos from previous section that discuss about using promises.