### PR TITLE
Output warning for undefined data instead of rendering null

### DIFF
--- a/src/decorators/connectStore.js
+++ b/src/decorators/connectStore.js
@@ -75,8 +75,8 @@ export default function connectStore(selector, prop = 'data', pureProps = true) 
       const { observer } = this.context
       const { data } = this.state
 
-      if (data === undefined) {
-        return null
+      if (process.env.NODE_ENV !== 'production' && data === undefined) {
+        console.error('Rendering `undefined` causes undefined behaviour in most cases! This message will only show up in development.')
       }
 
       return React.createElement(Child, {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+/*eslint-disable*/
 var webpack = require('webpack')
 var path = require('path')
 
@@ -5,7 +6,11 @@ var conf = {
   resolve: {
     extensions: [ '', '.js' ]
   },
-  plugins: [],
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': process.env.NODE_ENV || 'development'
+    })
+  ],
   module: {
     loaders: [
       {


### PR DESCRIPTION
This needs to be approved by multiple contributors first.

@alex3165 proposes to output a warning for `undefined` data instead of rendering `null`.